### PR TITLE
Add Ladder.h and Ladder.cpp to VS2017 project.

### DIFF
--- a/msvc/VS2017/leela-zero.vcxproj
+++ b/msvc/VS2017/leela-zero.vcxproj
@@ -28,6 +28,7 @@
     <ClInclude Include="..\..\src\GTP.h" />
     <ClInclude Include="..\..\src\Im2Col.h" />
     <ClInclude Include="..\..\src\KoState.h" />
+    <ClInclude Include="..\..\src\Ladder.h" />
     <ClInclude Include="..\..\src\Network.h" />
     <ClInclude Include="..\..\src\NNCache.h" />
     <ClInclude Include="..\..\src\ForwardPipe.h" />
@@ -57,6 +58,7 @@
     <ClCompile Include="..\..\src\GameState.cpp" />
     <ClCompile Include="..\..\src\GTP.cpp" />
     <ClCompile Include="..\..\src\KoState.cpp" />
+    <ClCompile Include="..\..\src\Ladder.cpp" />
     <ClCompile Include="..\..\src\Leela.cpp" />
     <ClCompile Include="..\..\src\Network.cpp" />
     <ClCompile Include="..\..\src\NNCache.cpp" />
@@ -83,7 +85,7 @@
     <ProjectGuid>{7B887BFE-8D2C-46CD-B139-5213434BF218}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>leelazero</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/msvc/VS2017/leela-zero.vcxproj.filters
+++ b/msvc/VS2017/leela-zero.vcxproj.filters
@@ -102,6 +102,9 @@
     <ClInclude Include="..\..\src\UCTNodePointer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\Ladder.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\FastBoard.cpp">
@@ -180,6 +183,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\UCTNodePointer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\Ladder.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Fixes linking error in Visual Studio (discovered when someone tried to compiled this for 9x9 training).